### PR TITLE
Supported for having in subquery

### DIFF
--- a/ormin/queries.nim
+++ b/ormin/queries.nim
@@ -396,7 +396,13 @@ proc cond(n: NimNode; q: var string; params: var Params;
           discard cond(cmd[1][1], subselect, params, DbType(kind: dbBool), qb)
         elif cmd[1].kind in nnkCallKinds and $cmd[1][0] == "groupby":
           subselect.add " group by "
-          discard cond(cmd[1][1], subselect, params, DbType(kind: dbBool), qb)
+          let hav = cmd[1][1]
+          if hav.kind in nnkCallKinds and $hav[1][0] == "having":
+            discard cond(hav[0], subselect, params, DbType(kind: dbBool), qb)
+            subselect.add " having "
+            discard cond(hav[1][1], subselect, params, DbType(kind: dbBool), qb)
+          else:
+            discard cond(hav, subselect, params, DbType(kind: dbBool), qb)
         else:
           error "construct not supported in condition: " & treeRepr cmd, cmd
       elif cmd.len >= 2:

--- a/tests/tforum.nim
+++ b/tests/tforum.nim
@@ -205,6 +205,18 @@ suite fmt"test common of {backend}":
                          .sortedByIt(it[0])
 
   test "query with having":
+    let id = 4
+    let res = query:
+      select post(author, count(_) as count)
+      groupby author
+      having author == ?id
+    let ct = postdata.mapIt(it.author).toCountTable()
+    {.push warning[deprecated]: off.}
+    let expected = lc[p | (p <- ct.pairs(), p[0] == id), tuple[author, count: int]]
+    {.pop.}
+    check res == expected
+
+  test "query with having: aggregate function":
     let countvalue = 2
     let res = query:
       select post(author, count(id) as count)
@@ -259,8 +271,16 @@ suite fmt"test common of {backend}":
                          .mapIt(it.thread)
                          .sortedByIt(it)
 
-  test "complex query":
+  test "subquery with having":
     # feature for having in subquery
+    let id = 4
+    let res = query:
+      select person(id)
+      where id in (
+        select post(author) groupby author having author == ?id)
+    check res == @[id]
+      
+  test "complex query with subquery and having":
     let
       id1 = 2
       id2 = 3


### PR DESCRIPTION
Ormin supports having clause，like:
```
    let countvalue = 2
    let res = query:
      select post(author, count(id) as count)
      groupby author
      having count(id) >= ?countvalue
```
but does not support using having clauses in subquery, like:
```
    let
      id1 = 2
      id2 = 3
    let res = query:
      select thread(count(_))
      where id in (
        select post(thread) where (author == ?id1 or author == ?id2) and id in (
          select post(min(id)) groupby thread having min(id) > 3))
```
I try to add this feature.