### PR TITLE
Support to custom type map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@ nimcache
 tools/ormin_importer
 tests/forum_model_sqlite.nim
 tests/forum_model_postgres.nim
-tests/model_postgres.nim
+tests/model_postgre.nim
 tests/tforum
 tests/tfunction
+tests/tpostgre
 examples/chat/chat_model.nim
 examples/chat/chatclient.nim
 examples/chat/createdb

--- a/config.nims
+++ b/config.nims
@@ -2,9 +2,10 @@ import strformat, strutils
 from os import `/`
 
 let
-  testDir = projectDir() / "tests"
+  testDir = thisDir() / "tests"
   commonTest = testDir / "tforum"
   commonFuncTest = testDir / "tfunction"
+  postgreTest = testDir / "tpostgre"
 
 proc parseArgs(): string =
   let numParams = paramCount()
@@ -56,3 +57,15 @@ task tfunction, "Test common sql functions":
   let args = parseArgs()
   initCommonDb(args)
   selfExec &"run {args} {commonFuncTest}"
+
+# Test task for special feature of postgresql:
+task initpostgre, "Init postgresql for specail test":
+  let sqlFile = testDir / "model_postgre.sql"
+  exec """psql -U test -wq -h localhost -c "drop table if exists alltype"
+  """
+  exec &"psql -U test -wq -h localhost -f {sqlFile}"
+
+task tpostgre, "Test special of postgresql":
+  let args = parseArgs()
+  selfExec "initpostgre"
+  selfExec &"run {args} {postgreTest}"

--- a/examples/chat/server.nim
+++ b/examples/chat/server.nim
@@ -14,13 +14,8 @@ var db {.global.} = open("chat.db", "", "", "")
 protocol "chatclient.nim":
   # A 'common' code section is shared by both the client and the server:
   common:
-    when not defined(js):
-      type kstring = string
-    type
-      inet = kstring
-      varchar = kstring
-      timestamp = kstring
-
+    when defined(js):
+      type string = cstring
 
   server "get recent messages":
     let lastMessages = query:

--- a/examples/chat/server.nim
+++ b/examples/chat/server.nim
@@ -14,8 +14,12 @@ var db {.global.} = open("chat.db", "", "", "")
 protocol "chatclient.nim":
   # A 'common' code section is shared by both the client and the server:
   common:
+    typemap:
+      kstring = string
     when defined(js):
-      type string = cstring
+      type kstring = cstring
+    else:
+      type kstring = string
 
   server "get recent messages":
     let lastMessages = query:

--- a/examples/forum/forum.nim
+++ b/examples/forum/forum.nim
@@ -3,6 +3,9 @@ import ormin, json
 
 importModel(DbBackend.sqlite, "forum_model")
 
+static:
+  dbtypetables.add(dbInet, "string")
+  
 var db {.global.} = open("stuff", "", "", "")
 
 #var db: DbConn

--- a/examples/forum/forum.nim
+++ b/examples/forum/forum.nim
@@ -4,7 +4,7 @@ import ormin, json
 importModel(DbBackend.sqlite, "forum_model")
 
 static:
-  dbtypetables.add(dbInet, "string")
+  dbTypeMap.add(dbInet, "string")
   
 var db {.global.} = open("stuff", "", "", "")
 

--- a/examples/forum/forumproto.nim
+++ b/examples/forum/forumproto.nim
@@ -4,14 +4,18 @@ import ormin, ormin/serverws, json
 importModel(DbBackend.sqlite, "forum_model")
 
 static:
-  dbtypetables.add(dbInet, "string")
+  dbTypeMap.add(dbInet, "string")
   
 var db {.global.} = open("stuff", "", "", "")
 
 protocol "forumclient.nim":
   common:
+    typemap:
+      kstring = string
     when defined(js):
-      type string = cstring
+      type kstring = cstring
+    else:
+      type kstring = string
 
   server:
     query:

--- a/examples/forum/forumproto.nim
+++ b/examples/forum/forumproto.nim
@@ -3,18 +3,16 @@ import ormin, ormin/serverws, json
 
 importModel(DbBackend.sqlite, "forum_model")
 
+static:
+  dbtypetables.add(dbInet, "string")
+  
 var db {.global.} = open("stuff", "", "", "")
 
 protocol "forumclient.nim":
   common:
     when defined(js):
-      type kstring = cstring
-    else:
-      type kstring = string
-    type
-      inet = kstring
-      varchar = kstring
-      timestamp = kstring
+      type string = cstring
+
   server:
     query:
       delete antibot

--- a/ormin.nimble
+++ b/ormin.nimble
@@ -20,6 +20,7 @@ task test, "Run all test suite":
   selfExec "tfunction"
   selfExec "-d:postgre tcommon"
   selfExec "-d:postgre tfunction"
+  selfExec "tpostgre"
 
 task buildexamples, "Build examples: chat and forum":
   selfExec "c examples/chat/server"

--- a/ormin/ormin_postgre.nim
+++ b/ormin/ormin_postgre.nim
@@ -8,7 +8,7 @@ type
   DbConn* = PPGconn    ## encapsulates a database connection
   PStmt* = string ## a identifier for the prepared queries
 
-var dbtypetables* {.compileTime.} = {
+var dbTypeMap* {.compileTime.} = {
   dbVarchar: "string",
   dbInt: "int",
   dbTimestamp: "string",

--- a/ormin/ormin_postgre.nim
+++ b/ormin/ormin_postgre.nim
@@ -1,16 +1,19 @@
 
-import strutils, postgres, json
+import strutils, postgres, json, tables
 
 import db_common
 export db_common
 
 type
   DbConn* = PPGconn    ## encapsulates a database connection
-  PStmt = string ## a identifier for the prepared queries
+  PStmt* = string ## a identifier for the prepared queries
 
-  varchar* = string
-  integer* = int
-  timestamp* = string
+var dbtypetables* {.compileTime.} = {
+  dbVarchar: "string",
+  dbInt: "int",
+  dbTimestamp: "string",
+  dbFloat: "float"
+}.toTable
 
 proc dbError*(db: DbConn) {.noreturn.} =
   ## raises a DbError exception.

--- a/ormin/ormin_sqlite.nim
+++ b/ormin/ormin_sqlite.nim
@@ -9,7 +9,7 @@ export db_common
 type
   DbConn* = PSqlite3  ## encapsulates a database connection
 
-var dbtypetables* {.compileTime.} = {
+var dbTypeMap* {.compileTime.} = {
   dbVarchar: "string",
   dbInt: "int",
   dbTimestamp: "string",

--- a/ormin/ormin_sqlite.nim
+++ b/ormin/ormin_sqlite.nim
@@ -1,16 +1,20 @@
 
 {.deadCodeElim: on.}
 
-import strutils, sqlite3, json
+import sqlite3, json, tables
 
 import db_common
 export db_common
 
 type
   DbConn* = PSqlite3  ## encapsulates a database connection
-  varchar* = string
-  integer* = int
-  timestamp* = string
+
+var dbtypetables* {.compileTime.} = {
+  dbVarchar: "string",
+  dbInt: "int",
+  dbTimestamp: "string",
+  dbFloat: "float"
+}.toTable
 
 proc dbError*(db: DbConn) {.noreturn.} =
   ## raises a DbError exception.

--- a/ormin/queries.nim
+++ b/ormin/queries.nim
@@ -5,7 +5,7 @@ when not declared(tableNames):
 when not declared(attributes):
   {.error: "The query DSL requires a attributes const.".}
 
-import macros, strutils, db_common
+import macros, strutils, db_common, tables
 from os import parentDir, `/`
 
 # SQL dialect specific things:
@@ -137,8 +137,8 @@ proc checkCompatibleSet(a, b: DbType; n: NimNode) =
   discard "too implement; might require a richer type system"
 
 proc toNimType(t: DbTypeKind): NimNode {.compileTime.} =
-  let name = ($t).substr(2).toLowerAscii
-  result = ident(name)
+  let typename = dbtypetables[t]
+  result = ident(typename)
 
 proc toNimType(t: DbType): NimNode {.compileTime.} = toNimType(t.kind)
 

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,1 +1,1 @@
---path:"$projectDir/../ormin"
+--path:"$projectDir/../../ormin"

--- a/tests/model_postgre.sql
+++ b/tests/model_postgre.sql
@@ -1,0 +1,9 @@
+create table if not exists alltype(
+  typserial serial primary key,
+  typinteger integer not null,
+  typbool boolean not null,
+  typfloat real not null,
+  typjson json not null,
+  jsonstr varchar not null,
+  typtimestamp timestamp not null default CURRENT_TIMESTAMP
+);

--- a/tests/tpostgre.nim
+++ b/tests/tpostgre.nim
@@ -1,0 +1,99 @@
+import unittest, json, postgres, strformat, strutils, sequtils, macros
+from db_postgres import exec, getValue
+import ormin
+
+importModel(DbBackend.postgre, "model_postgre")
+
+type
+  AllType = tuple[typinteger: int,
+                  typbool: bool,
+                  typfloat: float,
+                  typjson: JsonNode,
+                  jsonstr: string,
+                ]
+
+var typedata: seq[AllType]
+
+let rowcount = 5
+for i in 1..rowcount:
+  typedata.add((typinteger: i,
+                typbool: i mod 2 == 0,
+                typfloat: 0.5 + i.float,
+                typjson: %*{"name": &"bob{i}", "age": 29 + i},
+                jsonstr: $(%*{"type": "Point", "coordinates": [i, i.float]})
+              ))
+
+suite "postgre_special":
+  let db {.global.} = open("localhost", "test", "test", "test")
+
+  setup:
+    db.exec(sql"delete from alltype")
+
+    for t in typedata:
+      query:
+        insert alltype(typinteger = ?t.typinteger,
+                       typbool = ?t.typbool,
+                       typfloat = ?t.typfloat,
+                       typjson = ?(t.typjson),
+                       jsonstr = ?(t.jsonstr))
+                       
+    check db.getValue(sql"select count(*) from alltype") == $rowcount
+
+  test "query_dbSerial":
+    let res = query:
+      select alltype(typserial)
+    for s in res:
+      check s != 0
+    let resjson = query:
+      select alltype(typserial)
+      produce json
+    for j in resjson:
+      check j.kind == JObject
+      check j["typserial"].getInt() != 0
+
+  test "query_dbVarchar":
+    let res = query:
+      select alltype(jsonstr)
+    check res == typedata.mapIt(it.jsonstr)
+    let resjson = query:
+      select alltype(jsonstr)
+      produce json
+    check resjson == %typedata.mapIt(%*{"jsonstr": it.jsonstr})
+
+  test "query_dbInteger":
+    let res = query:
+      select alltype(typinteger)
+    check res == typedata.mapIt(it.typinteger)
+    let resjson = query:
+      select alltype(typinteger)
+      produce json
+    check resjson == %typedata.mapIt(%*{"typinteger": it.typinteger})
+
+  test "query_dbBool":
+    let res = query:
+      select alltype(typbool)
+    check res == typedata.mapIt(it.typbool)
+    let resjson = query:
+      select alltype(typbool)
+      produce json
+    check resjson == %typedata.mapIt(%*{"typbool": it.typbool})
+
+  test "query_dbFloat":
+    let res = query:
+      select alltype(typfloat)
+    check res == typedata.mapIt(it.typfloat)
+    let resjson =query:
+      select alltype(typfloat)
+      produce json
+    check resjson == %typedata.mapIt(%*{"typfloat": it.typfloat})
+
+  test "query_dbJson":
+    let res = query:
+      select alltype(typjson)
+    check res == typedata.mapIt(it.typjson)
+    let resjson = query:
+      select alltype(typjson)
+      produce json
+    check resjson == %typedata.mapIt(%*{"typjson": it.typjson})
+
+  db.close()


### PR DESCRIPTION
Allows custom database types to be mapped to nim types. Proc toNimType should find the corresponding nim type by looking up the table, rather than simply removing the first two letters of the database type,  and this implementation can add database types not supported by Ormin in user's code, maybe also overload the buildResult template.