### PR TITLE
Test on mulitple nim versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         nim:
           - 1.0.6
+          - devel
     name: Test on nim ${{ matrix.nim }}
     steps:
     - name: Checkout source code

--- a/tests/compat.nim
+++ b/tests/compat.nim
@@ -1,0 +1,59 @@
+
+when NimVersion < "1.2.0":
+  include system/inclrtl
+  import macros
+
+  proc transLastStmt(n, res, bracketExpr: NimNode): (NimNode, NimNode, NimNode) =
+    case n.kind
+    of nnkIfExpr, nnkIfStmt, nnkTryStmt, nnkCaseStmt:
+      result[0] = copyNimTree(n)
+      result[1] = copyNimTree(n)
+      result[2] = copyNimTree(n)
+      for i in ord(n.kind == nnkCaseStmt)..<n.len:
+        (result[0][i], result[1][^1], result[2][^1]) = transLastStmt(n[i], res, bracketExpr)
+    of nnkStmtList, nnkStmtListExpr, nnkBlockStmt, nnkBlockExpr, nnkWhileStmt,
+        nnkForStmt, nnkElifBranch, nnkElse, nnkElifExpr, nnkOfBranch, nnkExceptBranch:
+      result[0] = copyNimTree(n)
+      result[1] = copyNimTree(n)
+      result[2] = copyNimTree(n)
+      if n.len >= 1:
+        (result[0][^1], result[1][^1], result[2][^1]) = transLastStmt(n[^1], res, bracketExpr)
+    of nnkTableConstr:
+      result[1] = n[0][0]
+      result[2] = n[0][1]
+      if bracketExpr.len == 1:
+        bracketExpr.add([newCall(bindSym"typeof", newEmptyNode()), newCall(
+            bindSym"typeof", newEmptyNode())])
+      template adder(res, k, v) = res[k] = v
+      result[0] = getAst(adder(res, n[0][0], n[0][1]))
+    of nnkCurly:
+      result[2] = n[0]
+      if bracketExpr.len == 1:
+        bracketExpr.add(newCall(bindSym"typeof", newEmptyNode()))
+      template adder(res, v) = res.incl(v)
+      result[0] = getAst(adder(res, n[0]))
+    else:
+      result[2] = n
+      if bracketExpr.len == 1:
+        bracketExpr.add(newCall(bindSym"typeof", newEmptyNode()))
+      template adder(res, v) = res.add(v)
+      result[0] = getAst(adder(res, n))
+
+  macro collect*(init, body: untyped): untyped =
+    let res = genSym(nskVar, "collectResult")
+    expectKind init, {nnkCall, nnkIdent, nnkSym}
+    let bracketExpr = newTree(nnkBracketExpr,
+      if init.kind == nnkCall: init[0] else: init)
+    let (resBody, keyType, valueType) = transLastStmt(body, res, bracketExpr)
+    if bracketExpr.len == 3:
+      bracketExpr[1][1] = keyType
+      bracketExpr[2][1] = valueType
+    else:
+      bracketExpr[1][1] = valueType
+    let call = newTree(nnkCall, bracketExpr)
+    if init.kind == nnkCall:
+      for i in 1 ..< init.len:
+        call.add init[i]
+    result = newTree(nnkStmtListExpr, newVarStmt(res, call), resBody, res)
+
+


### PR DESCRIPTION
Tests can be run on multiple nim versions by replacing lc with collect and compat with 1.0.6, now tests run on 1.0.6 and devel version, but not 1.2 because of nim issue#14002. It is recommended that important fixes be moved to older versions as soon as possible.