### PR TITLE
Improved Static SQL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,20 @@ TODO:
 1. **Generate a model from SQL** – Place your schema in an `.sql` file and import it using `importModel`. The macro runs the `ormin_importer` tool and includes the generated Nim code for you
 2. **Create a database connection** – Ormin expects a global connection named `db` when issuing queries. The library ships drivers for SQLite and PostgreSQL; pick the matching backend in `importModel` and open a connection with Nim's database modules.
 
-If you also need to create or drop tables from schema embedded at compile time, use `ormin/db_utils` with `staticLoad("schema.sql")`, which returns a `DbSql` value and sanity-checks the SQL during compilation. Pass that `DbSql` to the `createTable` / `dropTable` overloads.
+If you also need to create or drop tables from schema embedded at compile time, use `ormin/db_utils` with `staticLoad("schema.sql")`, which returns a `DbSql` value and sanity-checks the SQL during compilation. Pass that `DbSql` to the `createTable` / `dropTable` overloads:
 
-Note Ormin 0.6+ properly handles quoted table names in `dropTable`. SQlite previously worked with incorrectly quoted tables. The compile flag  `-d:orminLegacySqliteDropNames` restores the older drop-table behavior that uses the normalized lookup name instead of the preserved SQL identifier.
+```nim
+import ormin/db_utils
+
+const schema = staticLoad("model.sql")
+
+db.createTable(schema)
+db.createTable(schema, "quoted table")
+db.dropTable(schema)
+db.dropTable(schema, "quoted table")
+```
+
+Note: Ormin now properly handles quoted table names in `dropTable`. SQLite previously tolerated the older normalized-name behavior for some schemas. The compile flag `-d:orminLegacySqliteDropNames` restores that older drop-table behavior by using the normalized lookup name instead of the preserved SQL identifier.
 
 ### SQLite
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TODO:
 2. **Create a database connection** – Ormin expects a global connection named `db` when issuing queries. The library ships drivers for SQLite and PostgreSQL; pick the matching backend in `importModel` and open a connection with Nim's database modules.
 
 If you also need to create or drop tables from a schema embedded with `staticRead`, use `ormin/db_utils` and the explicit static helpers such as `createTableStatic` / `dropTableStatic`.
+For SQLite only, `-d:orminLegacySqliteDropNames` restores the older drop-table behavior that uses the normalized lookup name instead of the preserved SQL identifier.
 
 ### SQLite
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ TODO:
 1. **Generate a model from SQL** – Place your schema in an `.sql` file and import it using `importModel`. The macro runs the `ormin_importer` tool and includes the generated Nim code for you
 2. **Create a database connection** – Ormin expects a global connection named `db` when issuing queries. The library ships drivers for SQLite and PostgreSQL; pick the matching backend in `importModel` and open a connection with Nim's database modules.
 
-If you also need to create or drop tables from a schema embedded with `staticRead`, use `ormin/db_utils` and the explicit static helpers such as `createTableStatic` / `dropTableStatic`.
-For SQLite only, `-d:orminLegacySqliteDropNames` restores the older drop-table behavior that uses the normalized lookup name instead of the preserved SQL identifier.
+If you also need to create or drop tables from schema embedded at compile time, use `ormin/db_utils` with `staticLoad("schema.sql")`, which returns a `DbSql` value and sanity-checks the SQL during compilation. Pass that `DbSql` to the `createTable` / `dropTable` overloads.
+
+Note Ormin 0.6+ properly handles quoted table names in `dropTable`. SQlite previously worked with incorrectly quoted tables. The compile flag  `-d:orminLegacySqliteDropNames` restores the older drop-table behavior that uses the normalized lookup name instead of the preserved SQL identifier.
 
 ### SQLite
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,18 @@ for row in db.postsIter(userId):
 
 Both forms accept parameters matching the `?`/`%` placeholders and produce the same return types as an inline `query` block.
 
+Inline `query` blocks resolve `db` from the current lexical scope, so a proc parameter or local `db` binding can override the global connection when needed. This is useful for making procs which need to do complex handling:
+
+```nim
+proc loadUser(db: DbConn; userId: int): User =
+  let row = query:
+    select user(id, name, email)
+    where id == ?userId
+    limit 1
+
+  User(id: row.id, name: row.name, email: row.email)
+```
+
 ## Running Arbitrary SQL
 
 The standard `db_connector` APIs can be imported and used. For example:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ TODO:
 1. **Generate a model from SQL** – Place your schema in an `.sql` file and import it using `importModel`. The macro runs the `ormin_importer` tool and includes the generated Nim code for you
 2. **Create a database connection** – Ormin expects a global connection named `db` when issuing queries. The library ships drivers for SQLite and PostgreSQL; pick the matching backend in `importModel` and open a connection with Nim's database modules.
 
+If you also need to create or drop tables from a schema embedded with `staticRead`, use `ormin/db_utils` and the explicit static helpers such as `createTableStatic` / `dropTableStatic`.
+
 ### SQLite
 
 ```nim

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ TODO:
 1. **Generate a model from SQL** – Place your schema in an `.sql` file and import it using `importModel`. The macro runs the `ormin_importer` tool and includes the generated Nim code for you
 2. **Create a database connection** – Ormin expects a global connection named `db` when issuing queries. The library ships drivers for SQLite and PostgreSQL; pick the matching backend in `importModel` and open a connection with Nim's database modules.
 
-If you also need to create or drop tables from schema embedded at compile time, use `ormin/db_utils` with `staticLoad("schema.sql")`, which returns a `DbSql` value and sanity-checks the SQL during compilation. Pass that `DbSql` to the `createTable` / `dropTable` overloads:
+### Static Schema
+
+The SQL file can be easily embedded at compile time. Import `ormin/db_utils` and use `const mySql = staticLoad("schema.sql")`, which returns a distinct string type `DbSql` after running sanity-checks the SQL. Pass that const `DbSql` to `createTable` / `dropTable` overloads:
 
 ```nim
 import ormin/db_utils
@@ -41,8 +43,6 @@ db.dropTable(schema)
 db.dropTable(schema, "quoted table")
 ```
 
-Note: Ormin now properly handles quoted table names in `dropTable`. SQLite previously tolerated the older normalized-name behavior for some schemas. The compile flag `-d:orminLegacySqliteDropNames` restores that older drop-table behavior by using the normalized lookup name instead of the preserved SQL identifier.
-
 ### SQLite
 
 ```nim
@@ -50,6 +50,8 @@ import ../ormin
 importModel(DbBackend.sqlite, "model_sqlite")
 let db {.global.} = open(":memory:", "", "", "")
 ```
+
+Note: Ormin now properly handles quoted table names in `dropTable`. The compile flag `-d:orminLegacySqliteDropNames` restores that older drop-table behavior by using the normalized lookup name instead of the preserved SQL identifier. The old behavior only worked in SQlite, not Postgres.
 
 ### PostgreSQL
 

--- a/ormin.nimble
+++ b/ormin.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.5.0"
+version       = "0.6.0"
 author        = "Araq"
 description = "Prepared SQL statement generator. A lightweight ORM."
 license       = "MIT"

--- a/ormin/db_utils.nim
+++ b/ormin/db_utils.nim
@@ -1,4 +1,4 @@
-import std/paths
+import std/[os, paths]
 import db_connector/db_common, strutils, strformat
 import db_connector/db_postgres as db_postgres
 import db_connector/db_sqlite as db_sqlite
@@ -13,6 +13,23 @@ type
   DbSql* = distinct string
 
 proc `$`*(dbId: DbId): string {.borrow.}
+proc `$`*(dbSql: DbSql): string {.borrow.}
+
+template staticLoad*(filename: string): DbSql =
+  bind isAbsolute, parentDir, `/`, instantiationInfo
+  block:
+    const schemaPath {.gensym.} = static:
+      if isAbsolute(filename):
+        filename
+      else:
+        parentDir(instantiationInfo(-1, true)[0]) / filename
+    const schemaSql {.gensym.} = staticRead(schemaPath)
+    static:
+      try:
+        discard parseSql(schemaSql)
+      except SqlParseError as e:
+        doAssert false, "Invalid SQL in " & schemaPath & ": " & e.msg
+    DbSql(schemaSql)
 
 proc parseQualifiedIdentifier(name: string): seq[(string, bool)] =
   var current = ""
@@ -82,11 +99,11 @@ proc dropTableName(db: DbConn; tableName, lookupName: string) =
     else:
       db.exec(sql("drop table if exists " & $tableIdentSql))
 
-iterator tableDefs(sql: string): tuple[name, tableName, model: string] =
+iterator tableDefs(sql: DbSql): tuple[name, tableName, model: string] =
   # Parse the entire SQL file and iterate statements via the SQL parser
   var ast: SqlNode
   try:
-    ast = parseSql(sql)
+    ast = parseSql($sql)
   except SqlParseError as e:
     echo "SQL Parse Error:\n", sql
     raise e
@@ -104,8 +121,13 @@ iterator tableDefs(sql: string): tuple[name, tableName, model: string] =
       yield (node[0].strVal.toLowerAscii(), $node[0], $node)
 
 iterator tablePairs*(sql: string): tuple[name, model: string] =
+  for name, _, model in tableDefs(DbSql(sql)):
+    yield (name, model)
+
+iterator tablePairs*(sql: DbSql): tuple[name, model: string] =
   for name, _, model in tableDefs(sql):
     yield (name, model)
+
 
 iterator tablePairs*(sql: Path): tuple[name, model: string] =
   let f = readFile($sql)
@@ -123,11 +145,11 @@ proc createTable*(db: DbConn; sqlFile: Path, name: string) =
       return
   raiseAssert &"table: {name} not found in: {sqlFile}"
 
-proc createTableStatic*(db: DbConn; schemaSql: static[string]) =
+proc createTable*(db: DbConn; schemaSql: DbSql) =
   for _, m in tablePairs(schemaSql):
     db.exec(sql(m))
 
-proc createTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
+proc createTable*(db: DbConn; schemaSql: DbSql, name: string) =
   for n, m in tablePairs(schemaSql):
     if n == name:
       db.exec(sql(m))
@@ -135,21 +157,21 @@ proc createTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
   raiseAssert &"table: {name} not found in static schema"
 
 proc dropTable*(db: DbConn; sqlFile: Path) =
-  for lookupName, tableName, _ in tableDefs(readFile($sqlFile)):
+  for lookupName, tableName, _ in tableDefs(readFile($sqlFile).DbSql):
     db.dropTableName(tableName, lookupName)
 
 proc dropTable*(db: DbConn; sqlFile: Path, name: string) =
-  for lookupName, tableName, _ in tableDefs(readFile($sqlFile)):
+  for lookupName, tableName, _ in tableDefs(readFile($sqlFile).DbSql):
     if lookupName == name:
       db.dropTableName(tableName, lookupName)
       return
   raiseAssert &"table: {name} not found in: {sqlFile}"
 
-proc dropTableStatic*(db: DbConn; schemaSql: static[string]) =
+proc dropTable*(db: DbConn; schemaSql: DbSql) =
   for lookupName, tableName, _ in tableDefs(schemaSql):
     db.dropTableName(tableName, lookupName)
 
-proc dropTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
+proc dropTable*(db: DbConn; schemaSql: DbSql, name: string) =
   for lookupName, tableName, _ in tableDefs(schemaSql):
     if lookupName == name:
       db.dropTableName(tableName, lookupName)

--- a/ormin/db_utils.nim
+++ b/ormin/db_utils.nim
@@ -7,9 +7,69 @@ import parsesql_tmp # import std/parsesql
 
 export paths
 
-type DbConn = db_postgres.DbConn | db_sqlite.DbConn
+type
+  DbConn = db_postgres.DbConn | db_sqlite.DbConn
+  DbId* = distinct string
 
-iterator tablePairs*(sql: string): tuple[name, model: string] =
+proc `$`*(dbId: DbId): string {.borrow.}
+
+proc parseQualifiedIdentifier(name: string): seq[(string, bool)] =
+  var current = ""
+  var quoteChar = '\0'
+  var partWasQuoted = false
+  var i = 0
+  while i < name.len:
+    let c = name[i]
+    if quoteChar == '\0':
+      case c
+      of '.':
+        result.add((current, partWasQuoted))
+        current = ""
+        partWasQuoted = false
+      of '"', '\'', '`':
+        if current.len == 0:
+          quoteChar = c
+          partWasQuoted = true
+        else:
+          current.add(c)
+      else:
+        current.add(c)
+    else:
+      if c == quoteChar:
+        if i + 1 < name.len and name[i + 1] == quoteChar:
+          current.add(c)
+          inc(i)
+        else:
+          quoteChar = '\0'
+      else:
+        current.add(c)
+    inc(i)
+
+  result.add((current, partWasQuoted))
+
+proc quoteDbIdentifier*(name: string): DbId =
+  ## Quote a database identifier for direct interpolation into SQL text.
+  ## Dot-separated names are treated as qualified identifiers.
+  var quotedParts: seq[string] = @[]
+  for (part, wasQuoted) in parseQualifiedIdentifier(name):
+    let normalizedPart =
+      if wasQuoted:
+        part
+      else:
+        part.toLowerAscii()
+    quotedParts.add("\"" & normalizedPart.replace("\"", "\"\"") & "\"")
+  DbId(quotedParts.join("."))
+
+proc dropTableName(db: DbConn; tableName: string) =
+  # SQL parameters bind values, not identifiers, so DROP TABLE needs the
+  # identifier rendered into the statement text with correct quoting.
+  let tableIdentSql = quoteDbIdentifier(tableName)
+  when defined(postgre):
+    db.exec(sql("drop table if exists " & $tableIdentSql & " cascade"))
+  else:
+    db.exec(sql("drop table if exists " & $tableIdentSql))
+
+iterator tableDefs(sql: string): tuple[name, tableName, model: string] =
   # Parse the entire SQL file and iterate statements via the SQL parser
   var ast: SqlNode
   try:
@@ -23,14 +83,16 @@ iterator tablePairs*(sql: string): tuple[name, model: string] =
     for i in 0 ..< ast.len:
       let node = ast[i]
       if node.kind in {nkCreateTable, nkCreateTableIfNotExists}:
-        let tableName = node[0].strVal.toLowerAscii()
-        yield (tableName, $node)
+        yield (node[0].strVal.toLowerAscii(), $node[0], $node)
   else:
     # Fallback: ast might be a single statement (not a list)
     let node = ast
     if node.kind in {nkCreateTable, nkCreateTableIfNotExists}:
-      let tableName = node[0].strVal.toLowerAscii()
-      yield (tableName, $node)
+      yield (node[0].strVal.toLowerAscii(), $node[0], $node)
+
+iterator tablePairs*(sql: string): tuple[name, model: string] =
+  for name, _, model in tableDefs(sql):
+    yield (name, model)
 
 iterator tablePairs*(sql: Path): tuple[name, model: string] =
   let f = readFile($sql)
@@ -48,17 +110,35 @@ proc createTable*(db: DbConn; sqlFile: Path, name: string) =
       return
   raiseAssert &"table: {name} not found in: {sqlFile}"
 
+proc createTableStatic*(db: DbConn; schemaSql: static[string]) =
+  for _, m in tablePairs(schemaSql):
+    db.exec(sql(m))
+
+proc createTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
+  for n, m in tablePairs(schemaSql):
+    if n == name:
+      db.exec(sql(m))
+      return
+  raiseAssert &"table: {name} not found in static schema"
+
 proc dropTable*(db: DbConn; sqlFile: Path) =
-  for n, _ in tablePairs(sqlFile):
-    when defined(postgre):
-      db.exec(sql("drop table if exists " & n & " cascade"))
-    else:
-      db.exec(sql("drop table if exists " & n))
+  for _, tableName, _ in tableDefs(readFile($sqlFile)):
+    db.dropTableName(tableName)
 
 proc dropTable*(db: DbConn; sqlFile: Path, name: string) =
-  for n, _ in tablePairs(sqlFile):
+  for n, tableName, _ in tableDefs(readFile($sqlFile)):
     if n == name:
-      when defined(postgre):
-        db.exec(sql("drop table if exists " & n & " cascade"))
-      else:
-        db.exec(sql("drop table if exists " & n))
+      db.dropTableName(tableName)
+      return
+  raiseAssert &"table: {name} not found in: {sqlFile}"
+
+proc dropTableStatic*(db: DbConn; schemaSql: static[string]) =
+  for _, tableName, _ in tableDefs(schemaSql):
+    db.dropTableName(tableName)
+
+proc dropTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
+  for n, tableName, _ in tableDefs(schemaSql):
+    if n == name:
+      db.dropTableName(tableName)
+      return
+  raiseAssert &"table: {name} not found in static schema"

--- a/ormin/db_utils.nim
+++ b/ormin/db_utils.nim
@@ -10,6 +10,7 @@ export paths
 type
   DbConn = db_postgres.DbConn | db_sqlite.DbConn
   DbId* = distinct string
+  DbSql* = distinct string
 
 proc `$`*(dbId: DbId): string {.borrow.}
 
@@ -69,14 +70,17 @@ proc quoteDbIdentifier*(name: string): DbId =
       partsSql.add(normalizedPart)
   DbId(partsSql.join("."))
 
-proc dropTableName(db: DbConn; tableName: string) =
+proc dropTableName(db: DbConn; tableName, lookupName: string) =
   # SQL parameters bind values, not identifiers, so DROP TABLE needs the
   # identifier rendered into the statement text with correct quoting.
-  let tableIdentSql = quoteDbIdentifier(tableName)
-  when defined(postgre):
-    db.exec(sql("drop table if exists " & $tableIdentSql & " cascade"))
+  when defined(sqlite) and defined(orminLegacySqliteDropNames):
+    db.exec(sql("drop table if exists " & lookupName))
   else:
-    db.exec(sql("drop table if exists " & $tableIdentSql))
+    let tableIdentSql = quoteDbIdentifier(tableName)
+    when defined(postgre):
+      db.exec(sql("drop table if exists " & $tableIdentSql & " cascade"))
+    else:
+      db.exec(sql("drop table if exists " & $tableIdentSql))
 
 iterator tableDefs(sql: string): tuple[name, tableName, model: string] =
   # Parse the entire SQL file and iterate statements via the SQL parser
@@ -131,23 +135,23 @@ proc createTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
   raiseAssert &"table: {name} not found in static schema"
 
 proc dropTable*(db: DbConn; sqlFile: Path) =
-  for _, tableName, _ in tableDefs(readFile($sqlFile)):
-    db.dropTableName(tableName)
+  for lookupName, tableName, _ in tableDefs(readFile($sqlFile)):
+    db.dropTableName(tableName, lookupName)
 
 proc dropTable*(db: DbConn; sqlFile: Path, name: string) =
-  for n, tableName, _ in tableDefs(readFile($sqlFile)):
-    if n == name:
-      db.dropTableName(tableName)
+  for lookupName, tableName, _ in tableDefs(readFile($sqlFile)):
+    if lookupName == name:
+      db.dropTableName(tableName, lookupName)
       return
   raiseAssert &"table: {name} not found in: {sqlFile}"
 
 proc dropTableStatic*(db: DbConn; schemaSql: static[string]) =
-  for _, tableName, _ in tableDefs(schemaSql):
-    db.dropTableName(tableName)
+  for lookupName, tableName, _ in tableDefs(schemaSql):
+    db.dropTableName(tableName, lookupName)
 
 proc dropTableStatic*(db: DbConn; schemaSql: static[string], name: string) =
-  for n, tableName, _ in tableDefs(schemaSql):
-    if n == name:
-      db.dropTableName(tableName)
+  for lookupName, tableName, _ in tableDefs(schemaSql):
+    if lookupName == name:
+      db.dropTableName(tableName, lookupName)
       return
   raiseAssert &"table: {name} not found in static schema"

--- a/ormin/db_utils.nim
+++ b/ormin/db_utils.nim
@@ -124,7 +124,7 @@ iterator tablePairs*(sql: string): tuple[name, model: string] =
   for name, _, model in tableDefs(DbSql(sql)):
     yield (name, model)
 
-iterator tablePairs*(sql: DbSql): tuple[name, model: string] =
+iterator tablePairs*(sql: static[DbSql]): tuple[name, model: string] =
   for name, _, model in tableDefs(sql):
     yield (name, model)
 
@@ -145,11 +145,11 @@ proc createTable*(db: DbConn; sqlFile: Path, name: string) =
       return
   raiseAssert &"table: {name} not found in: {sqlFile}"
 
-proc createTable*(db: DbConn; schemaSql: DbSql) =
+proc createTable*(db: DbConn; schemaSql: static[DbSql]) =
   for _, m in tablePairs(schemaSql):
     db.exec(sql(m))
 
-proc createTable*(db: DbConn; schemaSql: DbSql, name: string) =
+proc createTable*(db: DbConn; schemaSql: static[DbSql], name: string) =
   for n, m in tablePairs(schemaSql):
     if n == name:
       db.exec(sql(m))
@@ -157,21 +157,21 @@ proc createTable*(db: DbConn; schemaSql: DbSql, name: string) =
   raiseAssert &"table: {name} not found in static schema"
 
 proc dropTable*(db: DbConn; sqlFile: Path) =
-  for lookupName, tableName, _ in tableDefs(readFile($sqlFile).DbSql):
+  for lookupName, tableName, _ in tableDefs(DbSql(readFile($sqlFile))):
     db.dropTableName(tableName, lookupName)
 
 proc dropTable*(db: DbConn; sqlFile: Path, name: string) =
-  for lookupName, tableName, _ in tableDefs(readFile($sqlFile).DbSql):
+  for lookupName, tableName, _ in tableDefs(DbSql(readFile($sqlFile))):
     if lookupName == name:
       db.dropTableName(tableName, lookupName)
       return
   raiseAssert &"table: {name} not found in: {sqlFile}"
 
-proc dropTable*(db: DbConn; schemaSql: DbSql) =
+proc dropTable*(db: DbConn; schemaSql: static[DbSql]) =
   for lookupName, tableName, _ in tableDefs(schemaSql):
     db.dropTableName(tableName, lookupName)
 
-proc dropTable*(db: DbConn; schemaSql: DbSql, name: string) =
+proc dropTable*(db: DbConn; schemaSql: static[DbSql], name: string) =
   for lookupName, tableName, _ in tableDefs(schemaSql):
     if lookupName == name:
       db.dropTableName(tableName, lookupName)

--- a/ormin/db_utils.nim
+++ b/ormin/db_utils.nim
@@ -47,18 +47,27 @@ proc parseQualifiedIdentifier(name: string): seq[(string, bool)] =
 
   result.add((current, partWasQuoted))
 
+proc canUseBareIdentifier(part: string): bool =
+  if part.len == 0:
+    return false
+  if part[0] notin {'a'..'z', 'A'..'Z', '_'}:
+    return false
+  for c in part[1..^1]:
+    if c notin {'a'..'z', 'A'..'Z', '0'..'9', '_'}:
+      return false
+  true
+
 proc quoteDbIdentifier*(name: string): DbId =
   ## Quote a database identifier for direct interpolation into SQL text.
   ## Dot-separated names are treated as qualified identifiers.
-  var quotedParts: seq[string] = @[]
+  var partsSql: seq[string] = @[]
   for (part, wasQuoted) in parseQualifiedIdentifier(name):
-    let normalizedPart =
-      if wasQuoted:
-        part
-      else:
-        part.toLowerAscii()
-    quotedParts.add("\"" & normalizedPart.replace("\"", "\"\"") & "\"")
-  DbId(quotedParts.join("."))
+    let normalizedPart = if wasQuoted: part else: part.toLowerAscii()
+    if wasQuoted or not canUseBareIdentifier(normalizedPart):
+      partsSql.add("\"" & normalizedPart.replace("\"", "\"\"") & "\"")
+    else:
+      partsSql.add(normalizedPart)
+  DbId(partsSql.join("."))
 
 proc dropTableName(db: DbConn; tableName: string) =
   # SQL parameters bind values, not identifiers, so DROP TABLE needs the

--- a/ormin/parsesql_tmp.nim
+++ b/ormin/parsesql_tmp.nim
@@ -1093,7 +1093,10 @@ proc parseUnique(p: var SqlParser): SqlNode =
 proc parseTableDef(p: var SqlParser): SqlNode =
   result = parseIfNotExists(p, nkCreateTable)
   expectIdent(p)
-  result.add(newNode(nkIdent, p.tok.literal))
+  if p.tok.kind == tkQuotedIdentifier:
+    result.add(newNode(nkQuotedIdent, p.tok.literal))
+  else:
+    result.add(newNode(nkIdent, p.tok.literal))
   getTok(p)
   if p.tok.kind == tkParLe:
     getTok(p)

--- a/tests/db_utils_case_quoted.sql
+++ b/tests/db_utils_case_quoted.sql
@@ -16,3 +16,11 @@
   create table `Quoted Table2` (
     id integer primary key
   );
+
+  create table "UPPER_QUOTED" (
+    id integer primary key
+  );
+
+  create table "A""B" (
+    id integer primary key
+  );

--- a/tests/tdb_utils.nim
+++ b/tests/tdb_utils.nim
@@ -27,22 +27,58 @@ let sqlContent = """
   create table `Quoted Table2` (
     id integer primary key
   );
+
+  create table "UPPER_QUOTED" (
+    id integer primary key
+  );
+
+  create table "A""B" (
+    id integer primary key
+  );
 """
+
+const staticSqlContent = staticRead("db_utils_case_quoted.sql")
 
 writeFile($sqlFile, sqlContent)
 
 suite "db_utils: case and quoted names":
+  test "quoteDbIdentifier quotes and escapes identifiers":
+    check $quoteDbIdentifier("lower_table") == "\"lower_table\""
+    check $quoteDbIdentifier("UPPER_TABLE") == "\"upper_table\""
+    check $quoteDbIdentifier("\"Quoted Table\"") == "\"Quoted Table\""
+    check $quoteDbIdentifier("`Quoted Table2`") == "\"Quoted Table2\""
+    check $quoteDbIdentifier("'Quoted Table3'") == "\"Quoted Table3\""
+    check $quoteDbIdentifier("\"UPPER_TABLE\"") == "\"UPPER_TABLE\""
+    check $quoteDbIdentifier("\"A\"\"B\"") == "\"A\"\"B\""
+    check $quoteDbIdentifier("schema.table") == "\"schema\".\"table\""
+    check $quoteDbIdentifier("Schema.\"Mixed Table\"") == "\"schema\".\"Mixed Table\""
+    check $quoteDbIdentifier("weird\"name") == "\"weird\"\"name\""
+
   test "check tables names":
     let pairs = tablePairs(sqlContent).toSeq()
-    check pairs.len == 4
+    check pairs.len == 6
     check pairs[0][0] == ("lower_table")
     check pairs[1][0] == ("upper_table")
     check pairs[2][0] == ("quoted table")
     check pairs[3][0] == ("quoted table2")
+    check pairs[4][0] == ("upper_quoted")
+    check pairs[5][0] == ("a\"b")
 
     check pairs[0][1] == "create table lower_table(id  integer  primary key );"
     check pairs[1][1] == "create table UPPER_TABLE(id  integer  primary key );"
     check pairs[2][1] == "create table \"Quoted Table\"(id  integer  primary key );"
+    check pairs[4][1] == "create table \"UPPER_QUOTED\"(id  integer  primary key );"
+    check pairs[5][1] == "create table \"A\"\"B\"(id  integer  primary key );"
+
+  test "tablePairs parses compile-time SQL":
+    let pairs = tablePairs(staticSqlContent).toSeq()
+    check pairs.len == 6
+    check pairs[0][0] == "lower_table"
+    check pairs[1][0] == "upper_table"
+    check pairs[2][0] == "quoted table"
+    check pairs[3][0] == "quoted table2"
+    check pairs[4][0] == "upper_quoted"
+    check pairs[5][0] == "a\"b"
 
   test "createTable creates all tables from SQL file":
     db.createTable(sqlFile)
@@ -55,3 +91,49 @@ suite "db_utils: case and quoted names":
     db2.createTable(sqlFile, "quoted table")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table'")
     check countQuoted == "1"
+
+  test "createTableStatic creates all tables from compile-time SQL":
+    let db2 = open(":memory:", "", "", "")
+    db2.createTableStatic(staticSqlContent)
+    let countAll = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table','Quoted Table2','UPPER_QUOTED','A\"B')"))
+    check countAll == "6"
+
+  test "createTableStatic with specific lowercased name matches quoted":
+    let db2 = open(":memory:", "", "", "")
+    db2.createTableStatic(staticSqlContent, "quoted table")
+    let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table'")
+    check countQuoted == "1"
+
+  test "dropTable handles quoted names from SQL file":
+    let db2 = open(":memory:", "", "", "")
+    db2.createTable(sqlFile)
+    db2.dropTable(sqlFile, "quoted table2")
+    let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
+    check countQuoted == "0"
+
+    db2.dropTable(sqlFile, "upper_quoted")
+    let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
+    check countUpperQuoted == "0"
+
+    db2.dropTable(sqlFile, "a\"b")
+    let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
+    check countEscapedQuoted == "0"
+
+  test "dropTableStatic removes tables from compile-time SQL":
+    let db2 = open(":memory:", "", "", "")
+    db2.createTableStatic(staticSqlContent)
+    db2.dropTableStatic(staticSqlContent, "quoted table2")
+    let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
+    check countQuoted == "0"
+
+    db2.dropTableStatic(staticSqlContent, "upper_quoted")
+    let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
+    check countUpperQuoted == "0"
+
+    db2.dropTableStatic(staticSqlContent, "a\"b")
+    let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
+    check countEscapedQuoted == "0"
+
+    db2.dropTableStatic(staticSqlContent)
+    let countAll = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table')")
+    check countAll == "0"

--- a/tests/tdb_utils.nim
+++ b/tests/tdb_utils.nim
@@ -3,6 +3,8 @@ import db_connector/db_common
 from db_connector/db_sqlite import open, exec, getValue
 import ormin/db_utils
 
+const usesLegacySqliteDropNames = defined(sqlite) and defined(orminLegacySqliteDropNames)
+
 let
   db {.global.} = open(":memory:", "", "", "")
   testDir = currentSourcePath.parentDir()
@@ -113,21 +115,21 @@ suite "db_utils: case and quoted names":
     db2.createTable(sqlFile)
     db2.dropTable(sqlFile, "quoted table2")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countQuoted == "1"
     else:
       check countQuoted == "0"
 
     db2.dropTable(sqlFile, "upper_quoted")
     let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countUpperQuoted == "1"
     else:
       check countUpperQuoted == "0"
 
     db2.dropTable(sqlFile, "a\"b")
     let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countEscapedQuoted == "1"
     else:
       check countEscapedQuoted == "0"
@@ -137,28 +139,28 @@ suite "db_utils: case and quoted names":
     db2.createTable(staticSqlContent)
     db2.dropTable(staticSqlContent, "quoted table2")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countQuoted == "1"
     else:
       check countQuoted == "0"
 
     db2.dropTable(staticSqlContent, "upper_quoted")
     let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countUpperQuoted == "1"
     else:
       check countUpperQuoted == "0"
 
     db2.dropTable(staticSqlContent, "a\"b")
     let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countEscapedQuoted == "1"
     else:
       check countEscapedQuoted == "0"
 
     db2.dropTable(staticSqlContent)
     let countAll = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table','Quoted Table2','UPPER_QUOTED','A\"B')"))
-    when defined(orminLegacySqliteDropNames):
+    when usesLegacySqliteDropNames:
       check countAll == "3"
     else:
       check countAll == "0"

--- a/tests/tdb_utils.nim
+++ b/tests/tdb_utils.nim
@@ -109,31 +109,52 @@ suite "db_utils: case and quoted names":
     db2.createTable(sqlFile)
     db2.dropTable(sqlFile, "quoted table2")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
-    check countQuoted == "0"
+    when defined(orminLegacySqliteDropNames):
+      check countQuoted == "1"
+    else:
+      check countQuoted == "0"
 
     db2.dropTable(sqlFile, "upper_quoted")
     let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
-    check countUpperQuoted == "0"
+    when defined(orminLegacySqliteDropNames):
+      check countUpperQuoted == "1"
+    else:
+      check countUpperQuoted == "0"
 
     db2.dropTable(sqlFile, "a\"b")
     let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
-    check countEscapedQuoted == "0"
+    when defined(orminLegacySqliteDropNames):
+      check countEscapedQuoted == "1"
+    else:
+      check countEscapedQuoted == "0"
 
   test "dropTableStatic removes tables from compile-time SQL":
     let db2 = open(":memory:", "", "", "")
     db2.createTableStatic(staticSqlContent)
     db2.dropTableStatic(staticSqlContent, "quoted table2")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
-    check countQuoted == "0"
+    when defined(orminLegacySqliteDropNames):
+      check countQuoted == "1"
+    else:
+      check countQuoted == "0"
 
     db2.dropTableStatic(staticSqlContent, "upper_quoted")
     let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
-    check countUpperQuoted == "0"
+    when defined(orminLegacySqliteDropNames):
+      check countUpperQuoted == "1"
+    else:
+      check countUpperQuoted == "0"
 
     db2.dropTableStatic(staticSqlContent, "a\"b")
     let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
-    check countEscapedQuoted == "0"
+    when defined(orminLegacySqliteDropNames):
+      check countEscapedQuoted == "1"
+    else:
+      check countEscapedQuoted == "0"
 
     db2.dropTableStatic(staticSqlContent)
-    let countAll = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table')")
-    check countAll == "0"
+    let countAll = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table','Quoted Table2','UPPER_QUOTED','A\"B')"))
+    when defined(orminLegacySqliteDropNames):
+      check countAll == "3"
+    else:
+      check countAll == "0"

--- a/tests/tdb_utils.nim
+++ b/tests/tdb_utils.nim
@@ -37,11 +37,15 @@ let sqlContent = """
   );
 """
 
-const staticSqlContent = staticRead("db_utils_case_quoted.sql")
+const staticSqlContent = staticLoad("db_utils_case_quoted.sql")
 
 writeFile($sqlFile, sqlContent)
 
 suite "db_utils: case and quoted names":
+  test "staticLoad returns typed compile-time SQL":
+    let loaded: DbSql = staticSqlContent
+    check $loaded == sqlContent
+
   test "quoteDbIdentifier quotes and escapes identifiers":
     check $quoteDbIdentifier("lower_table") == "lower_table"
     check $quoteDbIdentifier("UPPER_TABLE") == "upper_table"
@@ -92,15 +96,15 @@ suite "db_utils: case and quoted names":
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table'")
     check countQuoted == "1"
 
-  test "createTableStatic creates all tables from compile-time SQL":
+  test "createTable creates all tables from compile-time SQL":
     let db2 = open(":memory:", "", "", "")
-    db2.createTableStatic(staticSqlContent)
+    db2.createTable(staticSqlContent)
     let countAll = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table','Quoted Table2','UPPER_QUOTED','A\"B')"))
     check countAll == "6"
 
-  test "createTableStatic with specific lowercased name matches quoted":
+  test "createTable with specific lowercased name matches quoted from compile-time SQL":
     let db2 = open(":memory:", "", "", "")
-    db2.createTableStatic(staticSqlContent, "quoted table")
+    db2.createTable(staticSqlContent, "quoted table")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table'")
     check countQuoted == "1"
 
@@ -128,31 +132,31 @@ suite "db_utils: case and quoted names":
     else:
       check countEscapedQuoted == "0"
 
-  test "dropTableStatic removes tables from compile-time SQL":
+  test "dropTable removes tables from compile-time SQL":
     let db2 = open(":memory:", "", "", "")
-    db2.createTableStatic(staticSqlContent)
-    db2.dropTableStatic(staticSqlContent, "quoted table2")
+    db2.createTable(staticSqlContent)
+    db2.dropTable(staticSqlContent, "quoted table2")
     let countQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'Quoted Table2'")
     when defined(orminLegacySqliteDropNames):
       check countQuoted == "1"
     else:
       check countQuoted == "0"
 
-    db2.dropTableStatic(staticSqlContent, "upper_quoted")
+    db2.dropTable(staticSqlContent, "upper_quoted")
     let countUpperQuoted = db2.getValue(sql"select count(*) from sqlite_master where type='table' and name = 'UPPER_QUOTED'")
     when defined(orminLegacySqliteDropNames):
       check countUpperQuoted == "1"
     else:
       check countUpperQuoted == "0"
 
-    db2.dropTableStatic(staticSqlContent, "a\"b")
+    db2.dropTable(staticSqlContent, "a\"b")
     let countEscapedQuoted = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name = 'A\"B'"))
     when defined(orminLegacySqliteDropNames):
       check countEscapedQuoted == "1"
     else:
       check countEscapedQuoted == "0"
 
-    db2.dropTableStatic(staticSqlContent)
+    db2.dropTable(staticSqlContent)
     let countAll = db2.getValue(sql("select count(*) from sqlite_master where type='table' and name in ('lower_table','UPPER_TABLE','Quoted Table','Quoted Table2','UPPER_QUOTED','A\"B')"))
     when defined(orminLegacySqliteDropNames):
       check countAll == "3"

--- a/tests/tdb_utils.nim
+++ b/tests/tdb_utils.nim
@@ -43,15 +43,15 @@ writeFile($sqlFile, sqlContent)
 
 suite "db_utils: case and quoted names":
   test "quoteDbIdentifier quotes and escapes identifiers":
-    check $quoteDbIdentifier("lower_table") == "\"lower_table\""
-    check $quoteDbIdentifier("UPPER_TABLE") == "\"upper_table\""
+    check $quoteDbIdentifier("lower_table") == "lower_table"
+    check $quoteDbIdentifier("UPPER_TABLE") == "upper_table"
     check $quoteDbIdentifier("\"Quoted Table\"") == "\"Quoted Table\""
     check $quoteDbIdentifier("`Quoted Table2`") == "\"Quoted Table2\""
     check $quoteDbIdentifier("'Quoted Table3'") == "\"Quoted Table3\""
     check $quoteDbIdentifier("\"UPPER_TABLE\"") == "\"UPPER_TABLE\""
     check $quoteDbIdentifier("\"A\"\"B\"") == "\"A\"\"B\""
-    check $quoteDbIdentifier("schema.table") == "\"schema\".\"table\""
-    check $quoteDbIdentifier("Schema.\"Mixed Table\"") == "\"schema\".\"Mixed Table\""
+    check $quoteDbIdentifier("schema.table") == "schema.table"
+    check $quoteDbIdentifier("Schema.\"Mixed Table\"") == "schema.\"Mixed Table\""
     check $quoteDbIdentifier("weird\"name") == "\"weird\"\"name\""
 
   test "check tables names":


### PR DESCRIPTION
- Adds static API variants of `createTable` and `dropTable`
- Fixes table quoting (on postgres) in `dropTable`
- Adds an opt-in static schema import path for importModel:
  `importModel(..., includeStatic = true)` now builds model metadata directly from
  the .sql file at compile time, exposes the raw SQL as a global sqlSchema, and avoids 
  relying on a generated .nim model file. The default path still uses `tools/ormin_importer`,
  which now only handles normal file generation through the shared generator code.
